### PR TITLE
Fix bugs and improve token handling and pagination in n8n node

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,31 @@
+name: Publish NPM Package
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the package
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+*.env
+CLAUDE.md

--- a/dist/credentials/MsGraphOAuth2Api.credentials.js
+++ b/dist/credentials/MsGraphOAuth2Api.credentials.js
@@ -4,8 +4,8 @@ exports.MsGraphOAuth2Api = void 0;
 class MsGraphOAuth2Api {
     constructor() {
         this.name = 'msGraphOAuth2Api';
-        this.displayName = 'Microsoft Graph OAuth2 API';
-        this.documentationUrl = 'https://docs.microsoft.com/en-us/graph/auth-v2-user';
+        this.displayName = 'Microsoft Graph Multi-Tenant';
+        this.documentationUrl = 'https://learn.microsoft.com/en-us/graph/auth-v2-service';
         this.properties = [
             {
                 displayName: 'Client ID',
@@ -23,30 +23,6 @@ class MsGraphOAuth2Api {
                 },
                 default: '',
                 required: true,
-            },
-            {
-                displayName: 'Scope',
-                name: 'scope',
-                type: 'string',
-                default: 'offline_access user.read',
-                description: 'Space-separated list of scopes to request',
-                required: true,
-            },
-            {
-                displayName: 'Authentication',
-                name: 'authentication',
-                type: 'options',
-                options: [
-                    {
-                        name: 'Body',
-                        value: 'body',
-                    },
-                    {
-                        name: 'Header',
-                        value: 'header',
-                    },
-                ],
-                default: 'header',
             },
         ];
     }

--- a/dist/nodes/MsGraph.node.js
+++ b/dist/nodes/MsGraph.node.js
@@ -21,6 +21,7 @@ class MsGraph {
         { displayName: 'Tenant ID', name: 'tenantId', type: 'string', default: '', placeholder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', description: 'Azure AD Tenant (Directory) ID', required: true },
         { displayName: 'HTTP Method', name: 'method', type: 'options', options: ['GET','POST','PATCH','PUT','DELETE'].map(m => ({ name: m, value: m })), default: 'GET' },
         { displayName: 'URL', name: 'url', type: 'string', default: 'https://graph.microsoft.com/v1.0/me', placeholder: 'https://graph.microsoft.com/v1.0/users', description: 'Full Graph URL', required: true },
+        { displayName: 'Return All Pages', name: 'returnAll', type: 'boolean', default: false, description: 'Whether to follow @odata.nextLink and return all pages as individual items', displayOptions: { show: { method: ['GET'] } } },
         { displayName: 'Query Parameters', name: 'queryParameters', type: 'fixedCollection', placeholder: 'Add Parameter', typeOptions: { multipleValues: true }, options: [{ name: 'parameter', displayName: 'Parameter', values: [ { displayName: 'Name', name: 'name', type: 'string', default: '' }, { displayName: 'Value', name: 'value', type: 'string', default: '' } ] }], default: {} },
         { displayName: 'Body', name: 'body', type: 'json', displayOptions: { show: { method: ['POST','PATCH','PUT'] } }, default: '', description: 'JSON body' },
         { displayName: 'Response Format', name: 'responseFormat', type: 'options', options: [ { name: 'JSON', value: 'json' }, { name: 'String', value: 'string' } ], default: 'json' },
@@ -33,19 +34,39 @@ class MsGraph {
     const returnItems = [];
     const tokenCache = {};
 
-    // Load client credentials once
     const oauthCreds = await this.getCredentials('msGraphOAuth2Api');
     const clientId = oauthCreds.clientId || oauthCreds.client_id;
     const clientSecret = oauthCreds.clientSecret || oauthCreds.client_secret;
+
+    // Shared retry logic for both token fetches and Graph API calls (429/503)
+    const requestWithRetry = async (options, maxRetries = 5) => {
+      let retryCount = 0;
+      while (true) {
+        try {
+          return await this.helpers.request(options);
+        } catch (error) {
+          if ((error.statusCode === 429 || error.statusCode === 503) && retryCount < maxRetries) {
+            retryCount++;
+            const retryAfterHeader = parseInt(error.response?.headers?.['retry-after'] || '0', 10);
+            // Respect Retry-After header when present; otherwise exponential backoff (2s, 4s, 8s… capped at 60s)
+            const delay = retryAfterHeader > 0 ? retryAfterHeader : Math.min(2 * Math.pow(2, retryCount - 1), 60);
+            await new Promise(resolve => setTimeout(resolve, delay * 1000));
+            continue;
+          }
+          throw error;
+        }
+      }
+    };
 
     for (let i = 0; i < items.length; i++) {
       try {
         const tenantId = this.getNodeParameter('tenantId', i);
 
-        // Fetch or reuse token for this tenant inline
-        let accessToken = tokenCache[tenantId];
+        // Fetch or reuse token; re-fetch if within 60s of expiry
+        const now = Date.now();
+        const cached = tokenCache[tenantId];
+        let accessToken = cached && cached.expiresAt > now + 60000 ? cached.token : null;
         if (!accessToken) {
-          // Inline getAccessTokenForTenant
           const tokenUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/token`;
           const params = new URLSearchParams();
           params.append('grant_type', 'client_credentials');
@@ -53,7 +74,7 @@ class MsGraph {
           params.append('client_secret', clientSecret);
           params.append('resource', 'https://graph.microsoft.com');
 
-          const tokenResponse = await this.helpers.request({
+          const tokenResponse = await requestWithRetry({
             method: 'POST',
             url: tokenUrl,
             body: params.toString(),
@@ -65,7 +86,8 @@ class MsGraph {
             throw new Error(`Failed to retrieve access token for tenant ${tenantId}`);
           }
           accessToken = tokenResponse.access_token;
-          tokenCache[tenantId] = accessToken;
+          const expiresIn = parseInt(tokenResponse.expires_in || '3600', 10);
+          tokenCache[tenantId] = { token: accessToken, expiresAt: now + expiresIn * 1000 };
         }
 
         // Build request parameters
@@ -85,34 +107,30 @@ class MsGraph {
         }
 
         const headers = { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' };
-        if (body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
+        if (body) headers['Content-Type'] = 'application/json';
 
         const responseFormat = this.getNodeParameter('responseFormat', i, 'json');
-        const requestOptions = { method, url, headers, qs, body, json: responseFormat === 'json', resolveWithFullResponse: true };
+        const returnAll = method === 'GET' ? this.getNodeParameter('returnAll', i, false) : false;
+        const requestOptions = { method, headers, qs, body, json: responseFormat === 'json' };
 
-        // Throttle retry
-        const throttle = { enabled: true, delay: 2, maxRetries: 5 };
-        let response;
-        let retryCount = 0;
-        while (true) {
-          try {
-            const fullResp = await this.helpers.request(requestOptions);
-            response = fullResp.body;
-            break;
-          } catch (error) {
-            if (error.statusCode === 429 && throttle.enabled && retryCount < throttle.maxRetries) {
-              retryCount++;
-              await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
-              continue;
+        if (returnAll) {
+          // Follow @odata.nextLink pages and emit one item per record
+          let nextUrl = url;
+          while (nextUrl) {
+            const page = await requestWithRetry({ ...requestOptions, url: nextUrl });
+            const values = Array.isArray(page.value) ? page.value : [page];
+            for (const value of values) {
+              const output = responseFormat === 'string' ? JSON.stringify(value) : value;
+              returnItems.push({ json: output });
             }
-            throw error;
+            nextUrl = page['@odata.nextLink'] || null;
           }
+        } else {
+          const response = await requestWithRetry({ ...requestOptions, url });
+          let output = response;
+          if (responseFormat === 'string') output = typeof response === 'object' ? JSON.stringify(response) : String(response);
+          returnItems.push({ json: output });
         }
-
-        let output = response;
-        if (responseFormat === 'string') output = typeof response === 'object' ? JSON.stringify(response) : String(response);
-
-        returnItems.push({ json: output });
       } catch (err) {
         if (this.continueOnFail()) {
           returnItems.push({ json: { error: err.message } });

--- a/index.js
+++ b/index.js
@@ -1,12 +1,2 @@
-module.exports = {
-	nodeTypes: {
-		MsGraph: {
-			sourcePath: './dist/nodes/MsGraph.node.js',
-		},
-	},
-	credentialTypes: {
-		MsGraphOAuth2Api: {
-			sourcePath: './dist/credentials/MsGraphOAuth2Api.credentials.js',
-		},
-	},
-}; 
+// n8n discovers nodes and credentials via the "n8n" key in package.json.
+// This file is the package main entry point and is not used for node discovery.

--- a/package.json
+++ b/package.json
@@ -1,16 +1,20 @@
 {
   "name": "n8n-nodes-msgraph-multitenant",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "type": "commonjs",
-  "description": "n8n node for consuming Microsoft Graph API, with mutlitenant capabilities",
+  "description": "n8n community node for calling the Microsoft Graph API across multiple Azure AD tenants",
   "keywords": [
     "n8n-community-node-package",
     "n8n",
     "microsoft",
     "graph",
     "msgraph",
+    "azure",
+    "azure-ad",
     "multi-tenant",
-    "mt"
+    "multitenant",
+    "office365",
+    "microsoft365"
   ],
   "license": "MIT",
   "homepage": "https://stream8.nl",
@@ -42,11 +46,11 @@
     "@typescript-eslint/eslint-plugin": "^8.26.1",
     "@typescript-eslint/parser": "^8.26.1",
     "eslint": "^8.57.1",
-    "eslint-plugin-n8n-nodes-base": "^1.16.1"
-  },
-  "dependencies": {
-    "n8n-core": "^1.0.0",
-    "n8n-workflow": "^1.0.0",
+    "eslint-plugin-n8n-nodes-base": "^1.16.1",
     "typescript": "^4.9.0"
+  },
+  "peerDependencies": {
+    "n8n-core": ">=1.0.0",
+    "n8n-workflow": ">=1.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,49 +1,60 @@
-# Multi-Tenant Microsoft Graph Node for N8N
+# n8n-nodes-msgraph-multitenant
 
-This repository provides a custom N8N node for interacting with the Microsoft Graph API across **multiple tenants**, based on a fork of [`advenimuss-n8n-nodes-msgraph`](https://github.com/advenimus/n8n-nodes-msgraph). It extends the original node by allowing dynamic data retrieval from **many Microsoft tenants** using a **multi-tenant Azure app registration**.
+A community node for [n8n](https://n8n.io) that lets you call the **Microsoft Graph API across multiple Azure AD tenants** from a single workflow. Each item in a workflow can target a different tenant — useful for MSPs and multi-tenant SaaS platforms.
 
+Forked from [`advenimus/n8n-nodes-msgraph`](https://github.com/advenimus/n8n-nodes-msgraph).
 
-## ⚙️ Prerequisites
+## Installation
 
-Before you begin, you’ll need:
+In your n8n instance, go to **Settings > Community Nodes** and install:
 
-- An [Azure AD multi-tenant app](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-convert-app-to-be-multi-tenant)
-- Appropriate Microsoft Graph API permissions
-- An N8N instance
+```
+n8n-nodes-msgraph-multitenant
+```
 
-## 🔐 Setting Up a Multi-Tenant App in Azure
+## Prerequisites
 
-To configure your Azure AD app for multi-tenant access:
+- A **multi-tenant Azure AD app registration** ([how to create one](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-convert-app-to-be-multi-tenant))
+- The app granted the required Microsoft Graph API permissions with **admin consent** from each tenant
+- A **client secret** for the app
 
-1. Log in to the [Azure Portal](https://portal.azure.com).
-2. Navigate to **Azure Active Directory** > **App registrations**.
-3. Click **New registration**.
-4. Set the **Supported account types** to:  
-   > ✅ *Accounts in any organizational directory (Any Azure AD directory - Multitenant)*
-5. After registration:
-   - Copy the **Application (client) ID**
-   - Copy the **Directory (tenant) ID**
-6. Go to **Certificates & secrets** and:
-   - Create a **client secret** or upload a **certificate** for authentication.
-7. In **API permissions**, add the required Microsoft Graph permissions (e.g., `User.Read.All`, `Group.Read.All`) and **grant admin consent**.
-8. Share the **consent URL** with each tenant admin so they can authorize your app.
+## Azure App Setup
 
+1. Go to [portal.azure.com](https://portal.azure.com) > **Azure Active Directory** > **App registrations** > **New registration**
+2. Set **Supported account types** to *Accounts in any organizational directory (Multitenant)*
+3. Copy the **Application (client) ID**
+4. Under **Certificates & secrets**, create a **client secret** and copy its value
+5. Under **API permissions**, add the Graph permissions your workflows need (e.g. `User.Read.All`, `Mail.Send`) and grant admin consent
+6. Share the consent URL with each tenant admin so they can authorize your app in their directory
 
-## 🚀 Basic Usage
+## Credentials
 
-1. **Install the NPM package** in your N8N instance using your preferred method (e.g., cloning the repo into your custom nodes directory).
-2. **Restart N8N** to load the new node.
-3. **Add the Microsoft Graph (Multi-Tenant)** node to your workflow.
-4. **Provide a Tenant ID**:
-   - Dynamically using expressions or looping over a list of tenant IDs.
-   - Or statically by hardcoding a single tenant ID if only one is required.
-5. **Configure the desired action** (e.g., list users, get groups, send email).
-6. **Execute the workflow** to fetch data from the Microsoft Graph API.
+Create a **Microsoft Graph Multi-Tenant** credential in n8n with:
 
-## 📄 License
+| Field | Value |
+|---|---|
+| Client ID | Application (client) ID from the app registration |
+| Client Secret | Secret value created above |
 
-This project is licensed under the **MIT License**.
+No redirect URI or OAuth flow is required — the node uses the **client credentials** grant.
 
-It is a fork of the original [advenimus/n8n-nodes-msgraph](https://github.com/advenimus/n8n-nodes-msgraph) project and includes modifications to support multi-tenant Microsoft Graph access in N8N.
+## Usage
 
-See the [LICENSE](./LICENSE) file for full license details.
+Add the **Microsoft Graph Multi-Tenant** node to your workflow and configure:
+
+| Parameter | Description |
+|---|---|
+| Tenant ID | Azure AD tenant (directory) ID for the target organization |
+| HTTP Method | GET, POST, PATCH, PUT, or DELETE |
+| URL | Full Graph API URL, e.g. `https://graph.microsoft.com/v1.0/users` |
+| Query Parameters | Optional key/value pairs appended to the URL |
+| Body | JSON body for POST/PATCH/PUT requests |
+| Response Format | JSON (default) or string |
+
+The **Tenant ID** field supports n8n expressions, so you can loop over a list of tenant IDs and call Graph for each one in a single workflow execution. Tokens are cached per tenant within a single execution to avoid redundant auth requests.
+
+**Throttling:** the node automatically retries on HTTP 429 responses, respecting the `Retry-After` header returned by Microsoft Graph (up to 5 retries).
+
+## License
+
+MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
* Create publish-npm.yml

* Update publish-npm.yml

* fix retry-after

* add .gitignore

* fix: add readme.md and package.json

* fix: remove resolveWithFullResponse, read response directly

resolveWithFullResponse is a request-promise option that does not work reliably in all n8n versions. The response body is now used directly, avoiding silent undefined output when the option is ignored.



* fix: remove unused Scope and Authentication credential fields

The node uses client credentials grant with a fixed resource URL — scope and authentication mode are never read. Showing them in the UI was misleading. Also updated documentationUrl to the service auth docs.



* fix: replace stale index.js node-discovery format

The nodeTypes/credentialTypes format is from an old n8n API. Discovery is handled by the "n8n" key in package.json — index.js only needs to exist as the package main entry point.



* fix: extract requestWithRetry helper with exponential backoff and 503 support

Previously the retry loop lived inline and only handled 429 with a fixed delay. Now a shared requestWithRetry helper covers both token fetches and Graph calls, handles 503 as well as 429, respects the Retry-After header when present, and falls back to exponential backoff (2 4 8 … 60s) otherwise.



* fix: track token expiry to prevent 401s in long-running executions

Tokens are now cached with their expiry time (from expires_in). A cached token is reused only if it has more than 60 seconds remaining, avoiding silent 401 failures when a workflow runs longer than the token lifetime.



* feat: add Return All Pages option to follow @odata.nextLink pagination

Without this, GET requests silently returned only the first page (default 100 items). When enabled, the node follows nextLink automatically and emits one output item per record, matching standard n8n node behaviour.



* fix: move n8n-core/n8n-workflow to peerDependencies, typescript to devDependencies

Bundling n8n-core and n8n-workflow adds unnecessary weight and risks version conflicts with the host n8n instance. typescript is build-only and has no place in runtime dependencies.



* release: bump versioning

---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive readme overhaul with streamlined installation via n8n Community Nodes, simplified Azure setup guidance, credentials configuration details, and parameter reference table.

* **Chores**
  * Established automated publish workflow for package distribution.
  * Updated package metadata and dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->